### PR TITLE
Add external hostname for RabbitMQ

### DIFF
--- a/templates/StatefulSet.yaml
+++ b/templates/StatefulSet.yaml
@@ -47,17 +47,21 @@ spec:
             - name: TB_QUEUE_RABBIT_MQ_PASSWORD
               value: {{ .Values.TB_RABBIT_MQ.TB_QUEUE_RABBIT_MQ_PASSWORD | quote }}
             - name: TB_QUEUE_RABBIT_MQ_HOST
+              {{- if .Values.rabbitmq.enabled }}
               value: {{ .Release.Name }}-{{ .Values.TB_RABBIT_MQ.TB_QUEUE_RABBIT_MQ_HOST }}
+              {{- else }}
+              value: {{ .Values.TB_RABBIT_MQ.TB_QUEUE_RABBIT_MQ_HOST }}
+              {{- end }}
             - name: TB_QUEUE_RABBIT_MQ_PORT
               value: {{ .Values.TB_RABBIT_MQ.TB_QUEUE_RABBIT_MQ_PORT | quote }}
-      {{ if .Values.readinessProbe.enabled }}
+      {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command:
                 - ls
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-      {{ end }}
+      {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
In case when There is RabbitMQ is already installed in the infrastructure it is now possible to specify its' hostname without a release name prefix. 